### PR TITLE
Add counter support to Triton

### DIFF
--- a/lib/triton/cql/update.ex
+++ b/lib/triton/cql/update.ex
@@ -30,6 +30,7 @@ defmodule Triton.CQL.Update do
   defp if_exists(_), do: ""
 
   defp value(nil, _), do: "NULL"
+  defp value(v, :counter), do: v
   defp value(v, {_, _}), do: v
   defp value(v, _) when is_boolean(v), do: "#{v}"
   defp value(v, _) when is_binary(v), do: binary_value(v)

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Triton.Mixfile do
 
   defp deps do
     [
-      {:xandra, "~> 0.7.1"},
+      {:xandra, "~> 0.9"},
       {:poolboy, "~> 1.5"},
       {:vex, "~> 0.6"}
     ]


### PR DESCRIPTION
This patch requires bumping Xandra to 0.9. It doesn't seem to create any breaking changes, but might be worthwhile to do a double check.