### PR TITLE
fix validation type coercion for comparison queries in issue #7

### DIFF
--- a/lib/triton/validate.ex
+++ b/lib/triton/validate.ex
@@ -39,9 +39,9 @@ defmodule Triton.Validate do
   defp coerce(fragments, fields) when is_list(fragments), do: fragments |> Enum.map(fn fragment -> coerce_fragment(fragment, fields) end)
   defp coerce(non_list, _), do: non_list
 
-  defp coerce_fragment({k, v}) when is_list(v), do: v |> Enum.map(fn {c, v} -> coerce_fragment({k, c, v}) end)
+  defp coerce_fragment({k, v}, fields) when is_list(v), do: {k, v |> Enum.map(fn {c, v} -> coerce_fragment({k, c, v}, fields) end)}
   defp coerce_fragment({k, v}, fields), do: {k, coerced_value(v, fields[k][:type])}
-  defp coerce_fragment({k, c, v}, fields), do: {k, c, coerced_value(v, fields[k][:type])}
+  defp coerce_fragment({k, c, v}, fields), do: {c, coerced_value(v, fields[k][:type])}
   defp coerce_fragment(x, _), do: x
 
   defp coerced_value(value, _) when is_atom(value), do: value


### PR DESCRIPTION
Hey, the issue is only when comparing `:text` type fields. It does not happen when the field is `:bigint` or `:timestamp` because it does not pass through this validation:
`defp coerced_value(value, :text) when not is_binary(value), do: to_string(value)`

It was passing the list parameter directly to:
`defp coerced_value(value, _), do: value`
because it doesn't have a case that match `when is_list` on the `coerced_value` function. Only `:text` because lists are a `not is_binary` match.



