### PR TITLE
Fix error when using batch_execute

### DIFF
--- a/lib/triton/executor.ex
+++ b/lib/triton/executor.ex
@@ -69,24 +69,26 @@ defmodule Triton.Executor do
   """
   def batch_execute(queries, options \\ [])
   def batch_execute(queries, options) when is_list(queries) and length(queries) > 0 do
-    conn = List.first(queries) |> conn_for
-    batch = queries
-      |> Enum.map(fn query ->
-        {:ok, _, cql} = build_cql(query)
-        {cql, query[:prepared]}
-      end)
-      |> Enum.reduce(Xandra.Batch.new(), fn ({cql, prepared}, acc) ->
-        case prepared do
-          nil -> Xandra.Batch.add(acc, cql)
-          prepared ->
-            with {:ok, prepared_cql} <- Xandra.prepare(conn, cql, [pool: Xandra.Cluster] ++ options) do
-              Xandra.Batch.add(acc, prepared_cql, prepared)
-            end
-        end
-      end)
+    cluster = List.first(queries) |> cluster_for
+    Xandra.Cluster.run(cluster, fn conn ->
+      batch = queries
+        |> Enum.map(fn query ->
+          {:ok, _, cql} = build_cql(query)
+          {cql, query[:prepared]}
+        end)
+        |> Enum.reduce(Xandra.Batch.new(), fn ({cql, prepared}, acc) ->
+          case prepared do
+            nil -> Xandra.Batch.add(acc, cql)
+            prepared ->
+              with {:ok, prepared_cql} <- Xandra.prepare(conn, cql, options) do
+                Xandra.Batch.add(acc, prepared_cql, prepared)
+              end
+          end
+        end)
 
-    with {:ok, %Xandra.Void{}} <- Xandra.execute(conn, batch, [pool: Xandra.Cluster] ++ options),
-      do: {:ok, :success}
+      with {:ok, %Xandra.Void{}} <- Xandra.execute(conn, batch, options),
+        do: {:ok, :success}
+    end)
   end
   def batch_execute(_, _), do: {:ok, :success}
 
@@ -98,7 +100,7 @@ defmodule Triton.Executor do
   def execute(query, options \\ []) do
     with {:ok, query}     <- Triton.Validate.coerce(query),
          {:ok, type, cql} <- build_cql(query),
-         {:ok, results}   <- execute_cql(conn_for(query), type, cql, query[:prepared], options),
+         {:ok, results}   <- execute_cql(cluster_for(query), type, cql, query[:prepared], options),
     do: {:ok, results}
   end
 
@@ -114,60 +116,68 @@ defmodule Triton.Executor do
     end
   end
 
-  defp execute_cql(conn, :stream, cql, nil, options) do
-    with pages <- Xandra.stream_pages!(conn, cql, [], [pool: Xandra.Cluster] ++ options) do
+  defp execute_cql(cluster, :stream, cql, nil, options) do
+    with pages <- Xandra.Cluster.stream_pages!(cluster, cql, [], options) do
       results = pages
         |> Stream.flat_map(fn page -> Enum.to_list(page) |> format_results end)
       {:ok, results}
     end
   end
-  defp execute_cql(conn, :stream, cql, prepared, options) do
-    with {:ok, statement} <- Xandra.prepare(conn, cql, [pool: Xandra.Cluster] ++ options),
-         pages <- Xandra.stream_pages!(conn, statement, atom_to_string_keys(prepared), [pool: Xandra.Cluster] ++ options)
-    do
-      results = pages
-        |> Stream.flat_map(fn page -> Enum.to_list(page) |> format_results end)
-      {:ok, results}
-    end
+  defp execute_cql(cluster, :stream, cql, prepared, options) do
+    Xandra.Cluster.run(cluster, fn conn ->
+      with {:ok, statement} <- Xandra.prepare(conn, cql, options),
+           pages <- Xandra.stream_pages!(conn, statement, atom_to_string_keys(prepared), options)
+      do
+        results = pages
+          |> Stream.flat_map(fn page -> Enum.to_list(page) |> format_results end)
+        {:ok, results}
+      end
+    end)
   end
 
-  defp execute_cql(conn, :select, cql, nil, options) do
-    with {:ok, page} <- Xandra.execute(conn, cql, [], [pool: Xandra.Cluster] ++ options),
+  defp execute_cql(cluster, :select, cql, nil, options) do
+    with {:ok, page} <- Xandra.Cluster.execute(cluster, cql, [], options),
       do: {:ok, Enum.to_list(page) |> format_results}
   end
-  defp execute_cql(conn, :select, cql, prepared, options) do
-    with {:ok, statement} <- Xandra.prepare(conn, cql, [pool: Xandra.Cluster] ++ options),
-         {:ok, page} <- Xandra.execute(conn, statement, atom_to_string_keys(prepared), [pool: Xandra.Cluster] ++ options),
-      do: {:ok, Enum.to_list(page) |> format_results}
+  defp execute_cql(cluster, :select, cql, prepared, options) do
+    Xandra.Cluster.run(cluster, fn conn ->
+      with {:ok, statement} <- Xandra.prepare(conn, cql, options),
+           {:ok, page} <- Xandra.execute(conn, statement, atom_to_string_keys(prepared), options),
+        do: {:ok, Enum.to_list(page) |> format_results}
+    end)
   end
 
-  defp execute_cql(conn, :count, cql, nil, options) do
-    with {:ok, page} <- Xandra.execute(conn, cql, [], [pool: Xandra.Cluster] ++ options),
+  defp execute_cql(cluster, :count, cql, nil, options) do
+    with {:ok, page} <- Xandra.Cluster.execute(cluster, cql, [], options),
          count <- page |> Enum.to_list |> List.first |> Map.get("count"),
       do: {:ok, count}
   end
-  defp execute_cql(conn, :count, cql, prepared, options) do
-    with {:ok, statement} <- Xandra.prepare(conn, cql, [pool: Xandra.Cluster] ++ options),
-         {:ok, page} <- Xandra.execute(conn, statement, atom_to_string_keys(prepared), [pool: Xandra.Cluster] ++ options),
-         count <- page |> Enum.to_list |> List.first |> Map.get("count"),
-      do: {:ok, count}
+  defp execute_cql(cluster, :count, cql, prepared, options) do
+    Xandra.Cluster.run(cluster, fn conn ->
+      with {:ok, statement} <- Xandra.prepare(conn, cql, options),
+           {:ok, page} <- Xandra.execute(conn, statement, atom_to_string_keys(prepared), options),
+           count <- page |> Enum.to_list |> List.first |> Map.get("count"),
+        do: {:ok, count}
+    end)
   end
 
-  defp execute_cql(conn, _, cql, nil, options) do
-    with {:ok, %Xandra.Void{}} <- Xandra.execute(conn, cql, [], [pool: Xandra.Cluster] ++ options) do
+  defp execute_cql(cluster, _, cql, nil, options) do
+    with {:ok, %Xandra.Void{}} <- Xandra.Cluster.execute(cluster, cql, [], options) do
       {:ok, :success}
     else
       error -> error |> execute_error
     end
   end
-  defp execute_cql(conn, _, cql, prepared, options) do
-    with {:ok, statement} <- Xandra.prepare(conn, cql, [pool: Xandra.Cluster] ++ options),
-         {:ok, %Xandra.Void{}} <- Xandra.execute(conn, statement, atom_to_string_keys(prepared), [pool: Xandra.Cluster] ++ options)
-    do
-      {:ok, :success}
-    else
-      error -> error |> execute_error
-    end
+  defp execute_cql(cluster, _, cql, prepared, options) do
+    Xandra.Cluster.run(cluster, fn conn ->
+      with {:ok, statement} <- Xandra.prepare(conn, cql, options),
+           {:ok, %Xandra.Void{}} <- Xandra.execute(conn, statement, atom_to_string_keys(prepared), options)
+      do
+        {:ok, :success}
+      else
+        error -> error |> execute_error
+      end
+    end)
   end
 
   defp execute_error({:ok, %Xandra.Page{} = page}) do
@@ -184,5 +194,5 @@ defmodule Triton.Executor do
   defp string_to_atom_keys(list), do: list |> Enum.map(fn {k, v} -> {String.to_atom(k), v} end) |> Enum.into(%{})
   defp atom_to_string_keys(list), do: list |> Enum.map(fn {k, v} -> {to_string(k), v} end) |> Enum.into(%{})
 
-  defp conn_for(query), do: query[:__schema__].__keyspace__.__struct__.__conn__
+  defp cluster_for(query), do: query[:__schema__].__keyspace__.__struct__.__conn__
 end

--- a/lib/triton/executor.ex
+++ b/lib/triton/executor.ex
@@ -78,7 +78,10 @@ defmodule Triton.Executor do
       |> Enum.reduce(Xandra.Batch.new(), fn ({cql, prepared}, acc) ->
         case prepared do
           nil -> Xandra.Batch.add(acc, cql)
-          prepared -> Xandra.Batch.add(acc, Xandra.prepare(conn, cql, [pool: Xandra.Cluster] ++ options), prepared)
+          prepared ->
+            with {:ok, prepared_cql} <- Xandra.prepare(conn, cql, [pool: Xandra.Cluster] ++ options) do
+              Xandra.Batch.add(acc, prepared_cql, prepared)
+            end
         end
       end)
 

--- a/lib/triton/setup/keyspace.ex
+++ b/lib/triton/setup/keyspace.ex
@@ -7,6 +7,7 @@ defmodule Triton.Setup.Keyspace do
         |> Keyword.take([:nodes, :authentication])
 
       node_config = Keyword.put(node_config, :nodes, [node_config[:nodes] |> Enum.random()])
+      {:ok, _apps} = Application.ensure_all_started(:xandra)
       {:ok, conn} = Xandra.start_link(node_config)
 
       statement = build_cql(blueprint |> Map.delete(:__struct__))

--- a/lib/triton/setup/materialized_view.ex
+++ b/lib/triton/setup/materialized_view.ex
@@ -10,6 +10,7 @@ defmodule Triton.Setup.MaterializedView do
         |> Keyword.take([:nodes, :authentication, :keyspace])
 
       node_config = Keyword.put(node_config, :nodes, [node_config[:nodes] |> Enum.random()])
+      {:ok, _apps} = Application.ensure_all_started(:xandra)
       {:ok, conn} = Xandra.start_link(node_config)
 
       statement = build_cql(blueprint |> Map.delete(:__struct__))

--- a/lib/triton/setup/table.ex
+++ b/lib/triton/setup/table.ex
@@ -15,6 +15,7 @@ defmodule Triton.Setup.Table do
         |> Keyword.take([:nodes, :authentication, :keyspace])
 
       node_config = Keyword.put(node_config, :nodes, [node_config[:nodes] |> Enum.random()])
+      {:ok, _apps} = Application.ensure_all_started(:xandra)
       {:ok, conn} = Xandra.start_link(node_config)
 
       statement = build_cql(blueprint |> Map.delete(:__struct__))

--- a/lib/triton/supervisor.ex
+++ b/lib/triton/supervisor.ex
@@ -14,7 +14,7 @@ defmodule Triton.Supervisor do
 
   def init(config) do
     children = [
-      worker(Xandra, [[
+      worker(Xandra.Cluster, [[
         {:name, config[:conn]},
         {:after_connect, fn(conn) -> Xandra.execute(conn, "USE #{config[:keyspace]}") end}
         | config

--- a/mix.exs
+++ b/mix.exs
@@ -26,8 +26,7 @@ defmodule Triton.Mixfile do
 
   defp deps do
     [
-      {:xandra, "~> 0.9"},
-      {:poolboy, "~> 1.5"},
+      {:xandra, "~> 0.12"},
       {:vex, "~> 0.6"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,8 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
-  "db_connection": {:hex, :db_connection, "1.1.2", "2865c2a4bae0714e2213a0ce60a1b12d76a6efba0c51fbda59c9ab8d1accc7a8", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+%{
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "db_connection": {:hex, :db_connection, "2.1.0", "122e2f62c4906bf2e49554f1e64db5030c19229aa40935f33088e7d543aa79d0", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "vex": {:hex, :vex, "0.6.0", "4e79b396b2ec18cd909eed0450b19108d9631842598d46552dc05031100b7a56", [:mix], [], "hexpm"},
-  "xandra": {:hex, :xandra, "0.9.0", "bba12d0398bff685d513148627e140d26109fac5fb14830fae2bd292c52cfe52", [:mix], [{:db_connection, "~> 1.0", [hex: :db_connection, repo: "hexpm", optional: false]}], "hexpm"}}
+  "xandra": {:hex, :xandra, "0.12.0", "995d3392fe6d5fc1f7f341290c09aa489fbc8c231db05b6b5eeb88e42b1045ac", [:mix], [{:db_connection, "~> 2.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.7", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+}


### PR DESCRIPTION
batch_execute was previously failing with error "no function clause
matching in Xandra.Batch.add/3" due to passing in an Ok/Error Tuple from
`Xandra.prepare`.