### PR TITLE
Ensure xandra is fully started before executing setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Intellij idea
+*.iml
+.idea/

--- a/lib/triton/setup.ex
+++ b/lib/triton/setup.ex
@@ -16,6 +16,7 @@ defmodule Triton.Setup do
 
             node_config = Keyword.put(node_config, :nodes, [node_config[:nodes] |> Enum.random()])
 
+            {:ok, _apps} = Application.ensure_all_started(:xandra)
             {:ok, conn} = Xandra.start_link(node_config)
             Xandra.execute!(conn, "USE #{node_config[:keyspace]};", _params = [])
             Xandra.execute!(conn, statement, _params = [])


### PR DESCRIPTION
This should fix setup macro execution during compilation.

```
** (exit) exited in: GenServer.call(DBConnection.Watcher, {:watch, 
DBConnection.ConnectionPool.Supervisor, {DBConnection.ConnectionPool.Pool, 
{#PID<0.1252.0>, #Reference<0.2799630828.876740610.194775>,
 Xandra.Connection 
...(elided)

** (EXIT) no process: the process is not alive or there's no process currently 
associated with the given name, possibly because its application isn't started
```