### PR TITLE
Use Xandra.Cluster in Setup

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -4,10 +4,10 @@ config :triton,
   clusters: [
     [
       conn: TritonTests.Conn,
-      nodes: ["127.0.0.1"],
+      nodes: ["127.0.0.1", "127.0.0.2", "127.0.0.3"],
       pool_size: 10,
-      keyspace: "triton_tests"
+      keyspace: "triton_tests",
+      autodiscovery: false
     ]
   ],
   disable_compilation_migrations: true
-

--- a/lib/triton/setup/table.ex
+++ b/lib/triton/setup/table.ex
@@ -25,24 +25,26 @@ defmodule Triton.Setup.Table do
       end
 
     rescue
-      err -> IO.inspect(err)
+      err -> IO.inspect(err, label: inspect(schema_module))
     end
   end
 
   defp setup_p(schema_module, cluster) do
-    blueprint = Triton.Metadata.schema(schema_module).__struct__
+    name = cluster |> Keyword.get(:conn)
+    node_config = cluster |> Keyword.put(:name, name)
 
-    node_config =
-      cluster
-      |> Keyword.take([:nodes, :authentication, :keyspace])
-
-    node_config = Keyword.put(node_config, :nodes, [node_config[:nodes] |> Enum.random()])
     {:ok, _apps} = Application.ensure_all_started(:xandra)
-    {:ok, conn} = Xandra.start_link(node_config)
+    {:ok, _conn} =
+      case Xandra.Cluster.start_link(node_config) do
+        {:ok, pid} -> {:ok, pid}
+        {:error, {:already_started, pid}} -> {:ok, pid}
+      end
 
     statement = build_cql(schema_module)
-    Xandra.execute!(conn, "USE #{node_config[:keyspace]};", _params = [])
-    Xandra.execute!(conn, statement, _params = [])
+    Xandra.Cluster.run(name, fn conn ->
+      Xandra.execute!(conn, "USE #{node_config[:keyspace]};", _params = [])
+      Xandra.execute!(conn, statement, _params = [])
+    end)
   end
 
   def build_cql(schema_module) do

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Triton.Mixfile do
 
   defp deps do
     [
-      {:xandra, "~> 0.12"},
+      {:xandra, git: "https://github.com/blitzstudios/xandra", ref: "5a5c2984e4f1183e2b081c18b5590a131ba50c96"},
       {:vex, "~> 0.6"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,9 @@
 %{
-  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm", "4a0850c9be22a43af9920a71ab17c051f5f7d45c209e40269a1938832510e4d9"},
-  "db_connection": {:hex, :db_connection, "2.1.0", "122e2f62c4906bf2e49554f1e64db5030c19229aa40935f33088e7d543aa79d0", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm", "f398f3144db606de82ed42c2ddc69767f0607abdb796e8220de5f0fcf80f5ba4"},
+  "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},
+  "db_connection": {:hex, :db_connection, "2.4.2", "f92e79aff2375299a16bcb069a14ee8615c3414863a6fef93156aee8e86c2ff3", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "4fe53ca91b99f55ea249693a0229356a08f4d1a7931d8ffa79289b145fe83668"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm", "1b34655872366414f69dd987cb121c049f76984b6ac69f52fff6d8fd64d29cfd"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "f050061c87ad39478c942995b5a20c40f2c0bc06525404613b8b0474cb8bd796"},
+  "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "vex": {:hex, :vex, "0.6.0", "4e79b396b2ec18cd909eed0450b19108d9631842598d46552dc05031100b7a56", [:mix], [], "hexpm", "7e4d9b50dd72cf931b52aba3470513686007f2ad54832de37cdb659cc85ba73e"},
-  "xandra": {:hex, :xandra, "0.12.0", "995d3392fe6d5fc1f7f341290c09aa489fbc8c231db05b6b5eeb88e42b1045ac", [:mix], [{:db_connection, "~> 2.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.7", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "9a79716b59bc83451888e1fb938793223729d410f532e7f30aa47b700be284da"},
+  "xandra": {:git, "https://github.com/blitzstudios/xandra", "5a5c2984e4f1183e2b081c18b5590a131ba50c96", [ref: "5a5c2984e4f1183e2b081c18b5590a131ba50c96"]},
 }


### PR DESCRIPTION
More robust in the presence of a downed node.  Also doesn't Xandra.start_link against each individual node (when setup is run enough times that random covers them all), which produces a ton of log output when there's a down node.