### PR TITLE
support running transforms on streams

### DIFF
--- a/lib/triton/configuration.ex
+++ b/lib/triton/configuration.ex
@@ -42,4 +42,6 @@ defmodule Triton.Configuration do
     |> valid_consistency?()
   end
   def valid_consistency?(consistency), do: consistency in @consistency_types
+
+  def transform_streams?(), do: enabled?(:transform_streams)
 end

--- a/lib/triton/metadata.ex
+++ b/lib/triton/metadata.ex
@@ -82,4 +82,22 @@ defmodule Triton.Metadata do
       :materialized_view -> true
     end
   end
+
+  def transform_streams(schema_module) do
+    meta = metadata(schema_module)
+    case is_materialized_view(schema_module) do
+      false ->
+        meta.__struct__
+          .__schema__.__struct__.__transform_streams__
+      true ->
+        meta.__struct__
+          .__from_metadata__.__struct__
+          .__schema__.__struct__.__transform_streams__
+    end
+    |> case do
+      yes when yes in [true, "true"] -> true
+      no when no in [false, "false"] -> false
+      _ -> nil
+    end
+  end
 end

--- a/lib/triton/table.ex
+++ b/lib/triton/table.ex
@@ -24,6 +24,7 @@ defmodule Triton.Table do
   defmacro table(name, params, [do: block]) do
     dual_write_keyspace = params[:dual_write_keyspace]
     keyspace = params[:keyspace]
+    transform_streams = params[:transform_streams]
 
     quote do
       outer = __MODULE__
@@ -52,6 +53,7 @@ defmodule Triton.Table do
           { :__keyspace__, unquote(keyspace) },
           { :__dual_write_keyspace__, unquote(dual_write_keyspace) },
           { :__name__, unquote(name) },
+          { :__transform_streams__, unquote(transform_streams)},
           { :__fields__, Module.get_attribute(__MODULE__, :fields) }
           | Module.get_attribute(__MODULE__, :table)
         ])

--- a/test/metadata_test.exs
+++ b/test/metadata_test.exs
@@ -44,6 +44,24 @@ defmodule Triton.Metadata.Test do
     end
   end
 
+  defmodule TestTableWithTransformStreams do
+    use Triton.Table
+
+    table :test_table, [transform_streams: true] do
+      field :id1, :text
+      partition_key [:id1]
+    end
+  end
+
+  defmodule TestTableWithTransformStreamsFalse do
+    use Triton.Table
+
+    table :test_table, [transform_streams: false] do
+      field :id1, :text
+      partition_key [:id1]
+    end
+  end
+
   test "should get metadata" do
     assert(Triton.Metadata.metadata(TestTable) === TestTable.Metadata)
     assert(Triton.Metadata.metadata(TestView) === TestView.Metadata)
@@ -85,5 +103,11 @@ defmodule Triton.Metadata.Test do
     }
     assert(Triton.Metadata.fields(TestTable) === table_fields)
     assert(Triton.Metadata.fields(TestView) === view_fields)
+  end
+
+  test "verify transform_streams table setting" do
+    assert(Triton.Metadata.transform_streams(TestTable) === nil)
+    assert(Triton.Metadata.transform_streams(TestTableWithTransformStreams) === true)
+    assert(Triton.Metadata.transform_streams(TestTableWithTransformStreamsFalse) === false)
   end
 end

--- a/test/transform_stream_test.exs
+++ b/test/transform_stream_test.exs
@@ -1,0 +1,200 @@
+defmodule Triton.TransformStream.Tests do
+  use ExUnit.Case, async: false
+  import Triton.Query
+  alias __MODULE__.TestKeyspace
+  alias __MODULE__.TestTable
+
+  def to_string(s), do: Kernel.to_string(s)
+  defp execute_cql(cql) do
+    {:ok, _apps} = Application.ensure_all_started(:xandra)
+    {:ok, conn} =
+      Application.get_env(:triton, :clusters)
+      |> Enum.find(fn cluster -> cluster[:conn] == TritonTests.Conn end)
+      |> Keyword.take([:nodes])
+      |> Xandra.start_link()
+
+    Xandra.execute(conn, cql)
+  end
+
+  defp drop_test_keyspace(), do: execute_cql("drop keyspace if exists triton_tests;")
+  defp truncate_test_tables() do
+    execute_cql("truncate triton_tests.stream_transform_test_table")
+    execute_cql("truncate triton_tests.stream_transform_test_table_with_transform_true")
+    execute_cql("truncate triton_tests.stream_transform_test_table_with_transform_false")
+  end
+
+  defmodule TestKeyspace do
+    use Triton.Keyspace
+
+    keyspace :triton_tests, conn: TritonTests.Conn do
+      with_options [
+        replication: "{'class' : 'SimpleStrategy', 'replication_factor': 3}"
+      ]
+    end
+  end
+
+  defmodule TestTable do
+    use Triton.Table
+    import Triton.Query
+
+    table :stream_transform_test_table, [keyspace: TestKeyspace] do
+      field :id, :text
+      field :transformed, :int, transform: &Triton.TransformStream.Tests.to_string/1
+      partition_key [:id]
+    end
+  end
+
+  defmodule TestTableWithTransformStreams do
+    use Triton.Table
+    import Triton.Query
+
+    table :stream_transform_test_table_with_transform_true, [keyspace: TestKeyspace, transform_streams: true] do
+      field :id, :text
+      field :transformed, :int, transform: &Triton.TransformStream.Tests.to_string/1
+      partition_key [:id]
+    end
+  end
+
+  defmodule TestTableWithTransformStreamsFalse do
+    use Triton.Table
+    import Triton.Query
+
+    table :stream_transform_test_table_with_transform_false, [keyspace: TestKeyspace, transform_streams: false] do
+      field :id, :text
+      field :transformed, :int, transform: &Triton.TransformStream.Tests.to_string/1
+      partition_key [:id]
+    end
+  end
+
+  defmodule TestView do
+    use Triton.MaterializedView
+    import Triton.Query
+
+    materialized_view :stream_transform_test_mv, from: TestTable do
+      fields [
+        :id, :transformed
+      ]
+      partition_key [:transformed]
+      cluster_columns [:id]
+    end
+  end
+
+  defmodule TestViewWithTransformStreams do
+    use Triton.MaterializedView
+    import Triton.Query
+
+    materialized_view :stream_transform_test_mv_with_transform_True, from: TestTableWithTransformStreams do
+      fields [
+        :id, :transformed
+      ]
+      partition_key [:transformed]
+      cluster_columns [:id]
+    end
+  end
+
+  setup do
+#    drop_test_keyspace()
+    Triton.Setup.Keyspace.setup(TestKeyspace)
+    Triton.Setup.Table.setup(TestTable)
+    Triton.Setup.Table.setup(TestTableWithTransformStreams)
+    Triton.Setup.Table.setup(TestTableWithTransformStreamsFalse)
+    Triton.Setup.MaterializedView.setup(TestView)
+    Triton.Setup.MaterializedView.setup(TestViewWithTransformStreams)
+    {:ok, _} = truncate_test_tables()
+
+    :ok
+  end
+
+  test "transform_streams without transform setting true should not transform" do
+    {:ok, _} = execute_cql("insert into triton_tests.stream_transform_test_table(id, transformed) values ('1', 2)")
+
+    expected = %{id: "1", transformed: 2}
+    actual =
+      TestTable
+      |> select(:all)
+      |> where(id: "1")
+      |> TestTable.stream(page_size: 1)
+      |> elem(1)
+      |> Enum.at(0)
+
+    assert actual == expected
+
+    # MV
+    actual =
+      TestView
+      |> select(:all)
+      |> where(transformed: 2)
+      |> TestView.stream(page_size: 1)
+      |> elem(1)
+      |> Enum.at(0)
+
+    assert actual == expected
+  end
+
+  test "transform_streams true should transform" do
+    {:ok, _} = execute_cql("insert into triton_tests.stream_transform_test_table_with_transform_true(id, transformed) values ('1', 2)")
+    {:ok, _} = execute_cql("insert into triton_tests.stream_transform_test_table_with_transform_false(id, transformed) values ('1', 2)")
+
+    expected = %{id: "1", transformed: "2"}
+    actual =
+      TestTableWithTransformStreams
+      |> select(:all)
+      |> where(id: "1")
+      |> TestTableWithTransformStreams.stream(page_size: 1)
+      |> elem(1)
+      |> Enum.at(0)
+
+    assert actual == expected
+
+    # MV
+    actual =
+      TestViewWithTransformStreams
+      |> select(:all)
+      |> where(transformed: "2")
+      |> TestViewWithTransformStreams.stream(page_size: 1)
+      |> elem(1)
+      |> Enum.at(0)
+
+    assert actual == expected
+
+    # Table with explicit false
+    actual =
+      TestTableWithTransformStreamsFalse
+      |> select(:all)
+      |> where(id: "1")
+      |> TestTableWithTransformStreamsFalse.stream(page_size: 1, transform_streams: true)
+      |> elem(1)
+      |> Enum.at(0)
+    assert actual == expected
+  end
+
+  test "on query, transform_streams true, should transform" do
+    {:ok, _} = execute_cql("insert into triton_tests.stream_transform_test_table(id, transformed) values ('1', 2)")
+    {:ok, _} = execute_cql("insert into triton_tests.stream_transform_test_table_with_transform_false(id, transformed) values ('1', 2)")
+
+    assert Triton.Metadata.transform_streams(TestTable) === nil
+    assert Triton.Metadata.transform_streams(TestTableWithTransformStreamsFalse) === false
+
+    expected = %{id: "1", transformed: "2"}
+    actual =
+      TestTable
+      |> select(:all)
+      |> where(id: "1")
+      |> TestTable.stream(page_size: 1, transform_streams: true)
+      |> elem(1)
+      |> Enum.at(0)
+
+    assert actual == expected
+
+    expected = %{id: "1", transformed: "2"}
+    actual =
+      TestTableWithTransformStreamsFalse
+      |> select(:all)
+      |> where(id: "1")
+      |> TestTableWithTransformStreamsFalse.stream(page_size: 1, transform_streams: true)
+      |> elem(1)
+      |> Enum.at(0)
+
+    assert actual == expected
+  end
+end


### PR DESCRIPTION
This update will allow us 3 different ways to enable automatically running transforms on streams.

1. We can enable it on a specific query by passing `transform_streams: true` on a stream's options.
```
MessagesByDate
|> select(:all)
|> where(channel_id: 1)
|> MessagesByDate.stream(page_size: 20, transform_streams: true)
```
2. We can enable it at the table level with `transform_streams: true`. This will automatically apply transforms on all streams on the table. We can override the table value by passing in a specific value on the stream's options.
```
table :test_table, [transform_streams: true] do
  field :id1, :text
  field :transformed, :int, transform: &Triton.TransformStream.Tests.to_string/1
  partition_key [:id1]
end
```
3. We can enable it at config level.
```
config :trition,
  transform_streams: true
```