### PR TITLE
fix dialyzer errors

### DIFF
--- a/lib/triton/executor.ex
+++ b/lib/triton/executor.ex
@@ -108,6 +108,7 @@ defmodule Triton.Executor do
         |> Enum.map(fn {k, field} -> {k, field[:opts][:transform]} end)
       end
 
+      @dialyzer {:no_match, transform_entity: 2}
       defp transform_entity(entity, transforms) when is_list(transforms) do
         Enum.reduce(transforms, entity, fn {k, transform}, acc ->
           Map.put(acc, k, transform.(acc[k]))
@@ -413,6 +414,7 @@ defmodule Triton.Executor do
   end
   defp execute_error(error), do: error
 
+  @dialyzer {:no_match, format_results: 1}
   defp format_results(list) when is_list(list), do: list |> Enum.map(fn map -> string_to_atom_keys(map) end)
   defp format_results(_), do: nil
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,8 +28,9 @@ defmodule Triton.Mixfile do
   defp deps do
     [
       {:xandra, "~> 0.12"},
-      {:vex, "~> 0.6"},
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:vex, "~> 0.9.1"},
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:dialyxir, "~> 1.4.1", only: [:dev, :test], runtime: false},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,10 @@
 %{
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm", "4a0850c9be22a43af9920a71ab17c051f5f7d45c209e40269a1938832510e4d9"},
   "db_connection": {:hex, :db_connection, "2.1.0", "122e2f62c4906bf2e49554f1e64db5030c19229aa40935f33088e7d543aa79d0", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm", "f398f3144db606de82ed42c2ddc69767f0607abdb796e8220de5f0fcf80f5ba4"},
+  "dialyxir": {:hex, :dialyxir, "1.4.2", "764a6e8e7a354f0ba95d58418178d486065ead1f69ad89782817c296d0d746a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "516603d8067b2fd585319e4b13d3674ad4f314a5902ba8130cd97dc902ce6bbd"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm", "1b34655872366414f69dd987cb121c049f76984b6ac69f52fff6d8fd64d29cfd"},
+  "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "f050061c87ad39478c942995b5a20c40f2c0bc06525404613b8b0474cb8bd796"},
-  "vex": {:hex, :vex, "0.6.0", "4e79b396b2ec18cd909eed0450b19108d9631842598d46552dc05031100b7a56", [:mix], [], "hexpm", "7e4d9b50dd72cf931b52aba3470513686007f2ad54832de37cdb659cc85ba73e"},
+  "vex": {:hex, :vex, "0.9.1", "cb65348ebd1c4002861b65bef36e524c29d9a879c90119b2d0e674e323124277", [:mix], [], "hexpm", "a0f9f3959d127ad6a6a617c3f607ecfb1bc6f3c59f9c3614a901a46d1765bafe"},
   "xandra": {:hex, :xandra, "0.12.0", "995d3392fe6d5fc1f7f341290c09aa489fbc8c231db05b6b5eeb88e42b1045ac", [:mix], [{:db_connection, "~> 2.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.7", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "9a79716b59bc83451888e1fb938793223729d410f532e7f30aa47b700be284da"},
 }


### PR DESCRIPTION
Dialyzer complains when private method fallback matches have no usages -- but I think its good to keep it so I'm just having dialyzer skip those errors rather than removing the fallback function.