### PR TITLE
Xandra -> Xandra.Cluster for migrations.

### DIFF
--- a/lib/triton/setup.ex
+++ b/lib/triton/setup.ex
@@ -14,12 +14,12 @@ defmodule Triton.Setup do
               |> Enum.find(&(&1[:conn] == Triton.Metadata.conn(block[:__schema_module__])))
               |> Keyword.take([:nodes, :authentication, :keyspace])
 
-            node_config = Keyword.put(node_config, :nodes, [node_config[:nodes] |> Enum.random()])
+            node_config = Keyword.put(node_config, :nodes, node_config[:nodes])
 
             {:ok, _apps} = Application.ensure_all_started(:xandra)
-            {:ok, conn} = Xandra.start_link(node_config)
-            Xandra.execute!(conn, "USE #{node_config[:keyspace]};", _params = [])
-            Xandra.execute!(conn, statement, _params = [])
+            {:ok, conn} = Xandra.Cluster.start_link(node_config)
+            Xandra.Cluster.execute!(conn, "USE #{node_config[:keyspace]};", _params = [])
+            Xandra.Cluster.execute!(conn, statement, _params = [])
           rescue
             err -> IO.inspect(err)
           end

--- a/lib/triton/setup/keyspace.ex
+++ b/lib/triton/setup/keyspace.ex
@@ -7,12 +7,12 @@ defmodule Triton.Setup.Keyspace do
         |> Enum.find(&(&1[:conn] == blueprint.__conn__))
         |> Keyword.take([:nodes, :authentication])
 
-      node_config = Keyword.put(node_config, :nodes, [node_config[:nodes] |> Enum.random()])
+      node_config = Keyword.put(node_config, :nodes, node_config[:nodes])
       {:ok, _apps} = Application.ensure_all_started(:xandra)
-      {:ok, conn} = Xandra.start_link(node_config)
+      {:ok, conn} = Xandra.Cluster.start_link(node_config)
 
       statement = build_cql(schema_module)
-      Xandra.execute!(conn, statement, _params = [])
+      Xandra.Cluster.execute!(conn, statement, _params = [])
     rescue
       err -> IO.inspect(err)
     end

--- a/lib/triton/setup/materialized_view.ex
+++ b/lib/triton/setup/materialized_view.ex
@@ -33,13 +33,13 @@ defmodule Triton.Setup.MaterializedView do
       cluster
       |> Keyword.take([:nodes, :authentication, :keyspace])
 
-    node_config = Keyword.put(node_config, :nodes, [node_config[:nodes] |> Enum.random()])
+    node_config = Keyword.put(node_config, :nodes, node_config[:nodes])
     {:ok, _apps} = Application.ensure_all_started(:xandra)
-    {:ok, conn} = Xandra.start_link(node_config)
+    {:ok, conn} = Xandra.Cluster.start_link(node_config)
 
     statement = build_cql(schema_module)
-    Xandra.execute!(conn, "USE #{node_config[:keyspace]};", _params = [])
-    Xandra.execute!(conn, statement, _params = [])
+    Xandra.Cluster.execute!(conn, "USE #{node_config[:keyspace]};", _params = [])
+    Xandra.Cluster.execute!(conn, statement, _params = [])
   end
 
   def build_cql(schema_module) do

--- a/lib/triton/setup/table.ex
+++ b/lib/triton/setup/table.ex
@@ -36,13 +36,13 @@ defmodule Triton.Setup.Table do
       cluster
       |> Keyword.take([:nodes, :authentication, :keyspace])
 
-    node_config = Keyword.put(node_config, :nodes, [node_config[:nodes] |> Enum.random()])
+    node_config = Keyword.put(node_config, :nodes, node_config[:nodes])
     {:ok, _apps} = Application.ensure_all_started(:xandra)
-    {:ok, conn} = Xandra.start_link(node_config)
+    {:ok, conn} = Xandra.Cluster.start_link(node_config)
 
     statement = build_cql(schema_module)
-    Xandra.execute!(conn, "USE #{node_config[:keyspace]};", _params = [])
-    Xandra.execute!(conn, statement, _params = [])
+    Xandra.Cluster.execute!(conn, "USE #{node_config[:keyspace]};", _params = [])
+    Xandra.Cluster.execute!(conn, statement, _params = [])
   end
 
   def build_cql(schema_module) do


### PR DESCRIPTION
This is intended to improve resilience during migration. Before we were expected all nodes to be up and working otherwise we could randomly select a broken node. This instead uses Xandra.Cluster, so that even if one of the nodes are down it will still work.