### PR TITLE
WIP exploring better migration

### DIFF
--- a/lib/triton/setup.ex
+++ b/lib/triton/setup.ex
@@ -1,4 +1,6 @@
 defmodule Triton.Setup do
+  alias Triton.Setup.DbConnection
+
   defmacro __before_compile__(_) do
     module = __CALLER__.module
     statements = Module.get_attribute(module, :setup_statements)
@@ -17,8 +19,10 @@ defmodule Triton.Setup do
             node_config = Keyword.put(node_config, :nodes, node_config[:nodes])
 
             {:ok, _apps} = Application.ensure_all_started(:xandra)
-            {:ok, conn} = Xandra.Cluster.start_link(node_config)
+            {:ok, cluster} = DbConnection.get_cluster(node_config)
+            IO.puts "SETUP!!!!!!!!!"
             Xandra.Cluster.execute!(conn, "USE #{node_config[:keyspace]};", _params = [])
+            IO.puts "SETUP2!!!!!!!!!"
             Xandra.Cluster.execute!(conn, statement, _params = [])
           rescue
             err -> IO.inspect(err)

--- a/lib/triton/setup/db_connection.ex
+++ b/lib/triton/setup/db_connection.ex
@@ -1,0 +1,40 @@
+defmodule Triton.Setup.DbConnection do
+  def get_cluster(config) do
+    # nodes = Enum.shuffle(config[:nodes] || [])
+    nodes = config[:nodes] || []
+
+    node_config = Keyword.merge(config, [
+      name: __MODULE__,
+      nodes: nodes,
+      # backoff_type: :stop,
+      backoff_max: 5_000,
+      # connect_timeout: 2_000,
+      # refresh_topology_interval: 10_000,
+      queue_checkouts_before_connecting: [
+        max_size: 1000,
+        timeout: 50_000
+      ]
+    ])
+    |> Keyword.drop([:autodiscovery])
+
+    case Xandra.Cluster.start_link(node_config) do
+      {:ok, cluster} ->
+        IO.inspect(cluster, label: "new connection")
+        IO.inspect(nodes, label: "nodes")
+        test_connection(cluster)
+        |> IO.inspect(label: "test_connection")
+        {:ok, cluster}
+
+      {:error, {:already_started, cluster}} ->
+        IO.inspect(cluster, label: "already started")
+        {:ok, cluster}
+
+      {:error, _reason} = err ->
+        {:error, :connection_failed}
+    end
+  end
+
+  defp test_connection(cluster) do
+    Xandra.Cluster.execute!(cluster, "SELECT now() FROM system.local", _params = [])
+  end
+end

--- a/lib/triton/setup/keyspace.ex
+++ b/lib/triton/setup/keyspace.ex
@@ -1,4 +1,6 @@
 defmodule Triton.Setup.Keyspace do
+  alias Triton.Setup.DbConnection
+
   def setup(schema_module) do
     blueprint = schema_module.__struct__
     try do
@@ -9,10 +11,11 @@ defmodule Triton.Setup.Keyspace do
 
       node_config = Keyword.put(node_config, :nodes, node_config[:nodes])
       {:ok, _apps} = Application.ensure_all_started(:xandra)
-      {:ok, conn} = Xandra.Cluster.start_link(node_config)
+      {:ok, cluster} = DbConnection.get_cluster(node_config)
 
       statement = build_cql(schema_module)
-      Xandra.Cluster.execute!(conn, statement, _params = [])
+      IO.puts "KEYSPACE!!!!!!!!!"
+      Xandra.Cluster.execute!(cluster, statement, _params = [])
     rescue
       err -> IO.inspect(err)
     end

--- a/lib/triton/setup/materialized_view.ex
+++ b/lib/triton/setup/materialized_view.ex
@@ -1,4 +1,6 @@
 defmodule Triton.Setup.MaterializedView do
+  alias Triton.Setup.DbConnection
+
   def setup(schema_module) do
     blueprint = Triton.Metadata.schema(schema_module).__struct__
     try do
@@ -35,11 +37,12 @@ defmodule Triton.Setup.MaterializedView do
 
     node_config = Keyword.put(node_config, :nodes, node_config[:nodes])
     {:ok, _apps} = Application.ensure_all_started(:xandra)
-    {:ok, conn} = Xandra.Cluster.start_link(node_config)
+    {:ok, cluster} = DbConnection.get_cluster(node_config)
 
     statement = build_cql(schema_module)
-    Xandra.Cluster.execute!(conn, "USE #{node_config[:keyspace]};", _params = [])
-    Xandra.Cluster.execute!(conn, statement, _params = [])
+    IO.puts "MATERIALIZED VIEW!!!!!!!!!"
+    Xandra.Cluster.execute!(cluster, "USE #{node_config[:keyspace]};", _params = [])
+    Xandra.Cluster.execute!(cluster, statement, _params = [])
   end
 
   def build_cql(schema_module) do

--- a/lib/triton/setup/table.ex
+++ b/lib/triton/setup/table.ex
@@ -7,6 +7,8 @@ defmodule Triton.Setup.Table do
   @doc """
   Attempts to create tables at compile time by connecting to DB with Xandra
   """
+  alias Triton.Setup.DbConnection
+
   def setup(schema_module) do
     blueprint = Triton.Metadata.schema(schema_module).__struct__
     try do
@@ -38,11 +40,13 @@ defmodule Triton.Setup.Table do
 
     node_config = Keyword.put(node_config, :nodes, node_config[:nodes])
     {:ok, _apps} = Application.ensure_all_started(:xandra)
-    {:ok, conn} = Xandra.Cluster.start_link(node_config)
+    {:ok, cluster} = DbConnection.get_cluster(node_config)
 
     statement = build_cql(schema_module)
-    Xandra.Cluster.execute!(conn, "USE #{node_config[:keyspace]};", _params = [])
-    Xandra.Cluster.execute!(conn, statement, _params = [])
+    IO.puts "TABLE!!!!!!!!!"
+    Xandra.Cluster.execute!(cluster, "USE #{node_config[:keyspace]};", _params = [])
+    IO.puts "TABLE2!!!!!!!!!"
+    Xandra.Cluster.execute!(cluster, statement, _params = [])
   end
 
   def build_cql(schema_module) do


### PR DESCRIPTION
This isn't ready, but the gist is if we want to use `Xandra.Cluster` I think we need to not create a new cluster for every setup call. Otherwise we end up with MANY "zombie" pools just wasting load on our DB. Especially for our use case where we also call these setup calls at runtime in some cases.

The goals:
- migrations work alright even when a few nodes are invalid in xandra nodes list
- load is distributed across nodes rather than all blowing up the first node
- we reuse existing connections/pools so we don't needlessly make many connections/pools