### PR TITLE
Victor/struct default regex values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Intellij idea
 *.iml
 .idea/
+priv/native/

--- a/lib/triton/validate.ex
+++ b/lib/triton/validate.ex
@@ -36,7 +36,7 @@ defmodule Triton.Validate do
   end
   def validate(_, query, _), do: {:ok, query}
 
-  defp vex_validators(schema) do
+  def vex_validators(schema) do
     schema
     |> Enum.filter(fn({_, opts}) -> opts[:opts][:validators] end)
     |> Enum.map(fn {field, opts} ->

--- a/lib/triton/validate.ex
+++ b/lib/triton/validate.ex
@@ -12,8 +12,7 @@ defmodule Triton.Validate do
       type ->
         case Application.get_env(:triton, :disable_validation) do
           true -> {:ok, query}
-          _ ->
-            validate(type, query, Triton.Metadata.fields(query[:__schema_module__]))
+          _ -> validate(type, query, Triton.Metadata.fields(query[:__schema_module__]))
         end
     end
   end
@@ -43,8 +42,7 @@ defmodule Triton.Validate do
       validators = opts[:opts][:validators]
       |> Enum.map(fn {k, v} ->
         case k do
-          :format ->
-            {k, maybe_compile_regex(v)}
+          :format -> {k, maybe_compile_regex(v)}
           _ -> {k, v}
         end
       end)

--- a/lib/triton/validate.ex
+++ b/lib/triton/validate.ex
@@ -12,15 +12,15 @@ defmodule Triton.Validate do
       type ->
         case Application.get_env(:triton, :disable_validation) do
           true -> {:ok, query}
-          _ -> validate(type, query, Triton.Metadata.fields(query[:__schema_module__]))
+          _ ->
+            validate(type, query, Triton.Metadata.fields(query[:__schema_module__]))
         end
     end
   end
 
   def validate(:insert, query, schema) do
     data = query[:prepared] && query[:prepared] ++ (query[:insert] |> Enum.filter(fn {_, v} -> !is_atom(v) end)) || query[:insert]
-    vex = schema |> Enum.filter(fn({_, opts}) -> opts[:opts][:validators] end) |> Enum.map(fn {field, opts} -> {field, opts[:opts][:validators]} end)
-    case Vex.errors(data ++ [_vex: vex]) do
+    case Vex.errors(data ++ [_vex: vex_validators(schema)]) do
       [] -> {:ok, query}
       err_list -> {:error, err_list |> Triton.Error.vex_error}
     end
@@ -28,13 +28,39 @@ defmodule Triton.Validate do
   def validate(:update, query, schema) do
     data = query[:prepared] && query[:prepared] ++ (query[:update] |> Enum.filter(fn {_, v} -> !is_atom(v) end)) || query[:update]
     fields_to_validate = data |> Enum.map(&(elem(&1, 0)))
-    vex = schema |> Enum.filter(fn({_, opts}) -> opts[:opts][:validators] end) |> Enum.map(fn {field, opts} -> {field, opts[:opts][:validators]} end) |> Enum.filter(&(elem(&1, 0) in fields_to_validate))
+    vex = vex_validators(schema) |> Enum.filter(&(elem(&1, 0) in fields_to_validate))
     case Vex.errors(data ++ [_vex: vex]) do
       [] -> {:ok, query}
       err_list -> {:error, err_list |> Triton.Error.vex_error}
     end
   end
   def validate(_, query, _), do: {:ok, query}
+
+  defp vex_validators(schema) do
+    schema
+    |> Enum.filter(fn({_, opts}) -> opts[:opts][:validators] end)
+    |> Enum.map(fn {field, opts} ->
+      validators = opts[:opts][:validators]
+      |> Enum.map(fn {k, v} ->
+        case k do
+          :format ->
+            {k, maybe_compile_regex(v)}
+          _ -> {k, v}
+        end
+      end)
+      {field, validators}
+    end)
+  end
+
+  defp maybe_compile_regex(re) when is_binary(re) do
+    Regex.compile!(re)
+  end
+
+  defp maybe_compile_regex([with: re, message: m]) when is_binary(re) do
+    [with: Regex.compile!(re), message: m]
+  end
+
+  defp maybe_compile_regex(v), do: v
 
   defp coerce({:__schema_module__, v}, _), do: {:__schema_module__, v}
   defp coerce({:__table__, v}, _), do: {:__table__, v}

--- a/test/validate_test.exs
+++ b/test/validate_test.exs
@@ -132,6 +132,5 @@ defmodule Triton.Validate.Tests do
       display_name: [format: ~r/[a-zA-Z0-9]+/],
       display_name2: [format: [with: ~r/[a-zA-Z0-9]+/, message: "must contain only letters and numbers"]]
     ])
-
   end
 end

--- a/test/validate_test.exs
+++ b/test/validate_test.exs
@@ -23,6 +23,10 @@ defmodule Triton.Validate.Tests do
       field :id1, :text
       field :id2, :bigint
       field :data, :text
+      field :email, :text, validators: [format: "[^@]+@[^@]+"]
+      field :email2, :text, validators: [format: [with: "[^@]+@[^@]+", message: "must be a valid email address"]]
+      field :display_name, :text, validators: [format: ~r/[a-zA-Z0-9]+/]
+      field :display_name2, :text, validators: [format: [with: ~r/[a-zA-Z0-9]+/, message: "must contain only letters and numbers"]]
       partition_key [:id1]
       cluster_columns [:id2]
     end
@@ -117,5 +121,17 @@ defmodule Triton.Validate.Tests do
     result = Triton.Validate.coerce(query)
 
     assert(result === {:ok, query})
+  end
+
+  test "binaries in the format validator are compiled to regex" do
+    schema = Triton.Metadata.fields(TestTable)
+    validators = Triton.Validate.vex_validators(schema)
+    assert(validators === [
+      email: [format: ~r/[^@]+@[^@]+/],
+      email2: [format: [with: ~r/[^@]+@[^@]+/, message: "must be a valid email address"]],
+      display_name: [format: ~r/[a-zA-Z0-9]+/],
+      display_name2: [format: [with: ~r/[a-zA-Z0-9]+/, message: "must contain only letters and numbers"]]
+    ])
+
   end
 end


### PR DESCRIPTION
the problem we are solving here is that starting with Elixir 1.19 using regular expressions as default values in structs is not allowed. Our only current use case  is vex validators.
This PR allows you to use binary vs regex literal when defining schemas and compile binary to regex before each validations. 
Tested on the sleeperbot codebase (3 schemas) making sure that tests pass. Also run some benchmarks and the compilation overhead is negligible. 